### PR TITLE
Add ability to invoke lambda url

### DIFF
--- a/osdp/pipeline/osdp_application_stage.py
+++ b/osdp/pipeline/osdp_application_stage.py
@@ -7,4 +7,17 @@ from stacks.osdp_prototype_stack import OsdpPrototypeStack
 class OsdpApplicationStage(Stage):
     def __init__(self, scope: Construct, id: str, **kwargs):
         super().__init__(scope, id, **kwargs)
-        OsdpPrototypeStack(self, "OSDP-Prototype")
+
+        github_action_arn = f"arn:aws:iam::{self.account}:oidc-provider/token.actions.githubusercontent.com"
+
+        stack = OsdpPrototypeStack(self, "OSDP-Prototype", ui_function_invoke_arn=github_action_arn)
+
+        if stack.ui_construct.function_invoker_principal:
+            # For staging deploy, restrict the function to only be invoked by our GitHub Action
+            stack.ui_construct.function_invoker_principal.with_conditions(
+                {
+                    "StringLike": {
+                        "token.actions.githubusercontent.com:sub": "repo:nulib/osdp-prototype-ui:*"
+                    }
+                }
+            )

--- a/osdp/stacks/osdp_prototype_stack.py
+++ b/osdp/stacks/osdp_prototype_stack.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from aws_cdk import (
     Fn,
     RemovalPolicy,
@@ -19,7 +21,9 @@ ECR_IMAGE = "625046682746.dkr.ecr.us-east-1.amazonaws.com/osdp-iiif-fetcher:late
 
 
 class OsdpPrototypeStack(Stack):
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(
+        self, scope: Construct, construct_id: str, ui_function_invoke_arn: Optional[str] = None, **kwargs
+    ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         # Retrieve the 'tags' context value (expected to be a dict)
@@ -34,15 +38,16 @@ class OsdpPrototypeStack(Stack):
         suffix = Fn.select(4, Fn.split("-", unique_id))
 
         # Create the API
-        api_construct = ApiConstruct(self, "ApiConstruct")
+        self.api_construct = ApiConstruct(self, "ApiConstruct")
 
         # Create the UI
-        _ui_construct = UIConstruct(
+        self.ui_construct = UIConstruct(
             self,
             "UIConstruct",
             stack_id=suffix,
-            api_url=api_construct.api_url.url,
+            api_url=self.api_construct.api_url.url,
             auth_context=AmplifyAuthContext(self),
+            function_invoke_arn=ui_function_invoke_arn,
         )
 
         # S3 bucket for the IIIF Manifests (and other data)


### PR DESCRIPTION
This PR adds the ability to invoke the Build Function URL.

## The UI Construct

In the `UIConstruct` there is an optional `function_invoke_arn` which is the ARN the can invoke the build function. By default, it's `None` because the typical consumer of this app won't need it. 

It's pretty straightforward:

```python
if function_invoke_arn:
    self.function_invoker_principle = iam.WebIdentityPrincipal(function_invoke_arn)
    self.function_invoker_role = iam.Role(
        self,
        "UIBuildFunctionInvokeRole",
        assumed_by=self.function_invoker_principle,
        role_name="UIBuildFunctionInvokeRole",
    )

    self.function_invoker_role.add_to_policy(
        iam.PolicyStatement(
            actions=["lambda:InvokeFunctionUrl"],
            resources=[self.build_function.function_arn],
        )
    )
    self.build_function.add_permission(
        "BuildFunctionInvokePermission",
        principal=self.function_invoker_role,
        action="lambda:InvokeFunctionUrl",
    )
```

## The OsdpApplicationStage

More interesting is the `OsdpApplicationStage`.  The ARN is set as the Github's OIDC provided, which has been set up in our account, verified by:

```
aws iam list-open-id-connect-providers  
```

The principal is then restricted more to our org and repo.

```python
if stack.ui_construct.function_invoker_principal:
    # For staging deploy, restrict the function to only be invoked by our GitHub Action
    stack.ui_construct.function_invoker_principal.with_conditions(
        {
            "StringLike": {
                "token.actions.githubusercontent.com:sub": "repo:nulib/osdp-prototype-ui:*"
            }
        }
    )
```

This ensures that even if someone has the Lambda url for the staging stack, they cannot use it in another Github action.

## The UI

The UI has it's own [PR](https://github.com/nulib/osdp-prototype-ui/pull/1) for a Github Action