### PR TITLE
Reconfigure how principal is added

### DIFF
--- a/osdp/pipeline/osdp_application_stage.py
+++ b/osdp/pipeline/osdp_application_stage.py
@@ -1,4 +1,5 @@
 from aws_cdk import Stage
+from aws_cdk import aws_iam as iam
 
 from constructs import Construct
 from stacks.osdp_prototype_stack import OsdpPrototypeStack
@@ -10,10 +11,9 @@ class OsdpApplicationStage(Stage):
 
         github_action_arn = f"arn:aws:iam::{self.account}:oidc-provider/token.actions.githubusercontent.com"
 
-        stack = OsdpPrototypeStack(self, "OSDP-Prototype", ui_function_invoke_arn=github_action_arn)
+        principal = iam.WebIdentityPrincipal(
+            github_action_arn,
+            conditions={"StringLike": {"token.actions.githubusercontent.com:sub": "repo:nulib/osdp-prototype-ui:*"}},
+        )
 
-        if stack.ui_construct.function_invoker_principal:
-            # For staging deploy, restrict the function to only be invoked by our GitHub Action
-            stack.ui_construct.function_invoker_principal.with_conditions(
-                {"StringLike": {"token.actions.githubusercontent.com:sub": "repo:nulib/osdp-prototype-ui:*"}}
-            )
+        OsdpPrototypeStack(self, "OSDP-Prototype", ui_function_invoke_principal=principal)

--- a/osdp/stacks/osdp_prototype_stack.py
+++ b/osdp/stacks/osdp_prototype_stack.py
@@ -6,6 +6,7 @@ from aws_cdk import (
     Stack,
     Tags,
 )
+from aws_cdk import aws_iam as iam
 from aws_cdk import (
     aws_s3 as s3,
 )
@@ -22,7 +23,11 @@ ECR_IMAGE = "625046682746.dkr.ecr.us-east-1.amazonaws.com/osdp-iiif-fetcher:late
 
 class OsdpPrototypeStack(Stack):
     def __init__(
-        self, scope: Construct, construct_id: str, ui_function_invoke_arn: Optional[str] = None, **kwargs
+        self,
+        scope: Construct,
+        construct_id: str,
+        ui_function_invoke_principal: Optional[iam.WebIdentityPrincipal] = None,
+        **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
@@ -47,7 +52,7 @@ class OsdpPrototypeStack(Stack):
             stack_id=suffix,
             api_url=self.api_construct.api_url.url,
             auth_context=AmplifyAuthContext(self),
-            function_invoke_arn=ui_function_invoke_arn,
+            function_invoker_principal=ui_function_invoke_principal,
         )
 
         # S3 bucket for the IIIF Manifests (and other data)


### PR DESCRIPTION
The changes in PR #7 failed in the Pipeline with the following error:

```
Resource handler returned message: "Trust policy with trusted principal arn:aws:iam::625046682746:oidc-provider/token.actions.githubusercontent.com must evaluate, using StringEquals, StringLike or StringEqualsIgnoreCase, token.actions.githubusercontent.com:sub which is not scoped to all. (Service: Iam, Status Code: 400, Request ID: b653ff02-f701-4fd8-a220-8d37a2a62f15)" (RequestToken: bdf2f949-67a0-3009-3ecd-9b5a9c3cfc59, HandlerErrorCode: InvalidRequest)
```

This is because the condition for the principal was added in the Pipeline _after_ the stack was synthesized.

These changes:
- pass the principal, including conditions, down to the `UIConstruct`
- fix some policy issues
- append the stack name to the role name to ensure it is unique

---

I was able to test these changes by adding them to app.py

```python
# TEST
github_action_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
principal = iam.WebIdentityPrincipal(
    github_action_arn,
    conditions={"StringLike": {"token.actions.githubusercontent.com:sub": "repo:nulib/osdp-prototype-ui:*"}},
)

OsdpPrototypeStack(
    app,
    f"{stack_prefix}-OSDP-Prototype",
    ui_function_invoke_principal=principal,
    env=cdk.Environment(account=os.getenv("CDK_DEFAULT_ACCOUNT"), region=os.getenv("CDK_DEFAULT_REGION")),
)
```

and deploying my stack — but once staging is deployed, the Github action will need to be tested separately