### PR TITLE
Add Bedrock KnowledgeBase to CDK stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Since the `cdk.json` file is generally committed to source control, it should ge
 
 - `stack_prefix` (str) - will be appended to the beginning of the CloudFormation stack on deploy. (*For NU devs this is not required, it will use the `DEV_PREFIX` env var in AWS.)
 - `collection_url` (str)- the url of the IIIF collection to load during deployment. There is a small collection (6 items) in the `cdk.json` file, but you will want to change or override on the command line.
+- `embedding_model_arn` (str) - Embedding model to use for Bedrock Knowledgebase
 
 #### Optional context values
 

--- a/iiif/manifest_fetcher.py
+++ b/iiif/manifest_fetcher.py
@@ -4,11 +4,9 @@ import os
 import boto3
 from loam_iiif.iiif import IIIFClient
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
 
 def fetch_collection(url):
     try:
@@ -18,40 +16,38 @@ def fetch_collection(url):
         logger.error(f"An error occurred: {e}")
         raise
 
-    logger.info(
-        f"Found {len(manifests)} manifests and {len(collections)} collections."
-    )
+    logger.info(f"Found {len(manifests)} manifests and {len(collections)} collections.")
 
     return manifests
 
+
 def main():
-    url = os.environ.get('COLLECTION_URL')
+    url = os.environ.get("COLLECTION_URL")
     if not url:
         logger.error("No COLLECTION_URL environment variable set")
         return
 
-    bucket_name = os.environ.get('BUCKET_NAME')
+    bucket_name = os.environ.get("BUCKET_NAME")
     if not bucket_name:
         logger.error("No BUCKET_NAME environment variable set")
         return
 
     manifests_urls = fetch_collection(url)
-    data = '\n'.join(manifests_urls)
+    data = "\n".join(manifests_urls)
 
     try:
-        s3 = boto3.client('s3')
+        s3 = boto3.client("s3")
 
         respone = s3.put_object(
-            Body=bytes(data, encoding='utf-8'),
+            Body=bytes(data, encoding="utf-8"),
             Bucket=bucket_name,
             Key="manifests.csv",
-            ContentType='text/csv'
+            ContentType="text/csv",
         )
         logger.info(f"Uploaded file to S3: {respone}")
     except Exception as e:
         logger.error(f"An error occurred uploading file to S3: {e}")
         raise
-
 
     logger.info("Task completed successfully")
 

--- a/osdp/app.py
+++ b/osdp/app.py
@@ -11,7 +11,7 @@ from stacks.osdp_prototype_stack import OsdpPrototypeStack
 app = cdk.App()
 
 # All the required context keys
-required_context = ["collection_url"]
+required_context = ["collection_url", "embedding_model_arn"]
 
 # Validate that each required context is provided
 for key in required_context:
@@ -35,6 +35,7 @@ if not stack_prefix:
 OsdpPrototypeStack(
     app,
     f"{stack_prefix}-OSDP-Prototype",
+    stack_prefix=stack_prefix,
     # If you don't specify 'env', this stack will be environment-agnostic.
     # Account/Region-dependent features and context lookups will not work,
     # but a single synthesized template can be deployed anywhere.
@@ -46,5 +47,7 @@ OsdpPrototypeStack(
     # env=cdk.Environment(account='123456789012', region='us-east-1'),
     # For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
 )
-PipelineStack(app, "OsdpPipelineStack", env=cdk.Environment(account="625046682746", region="us-east-1"))
+PipelineStack(
+    app, "OsdpPipelineStack", stack_prefix="staging", env=cdk.Environment(account="625046682746", region="us-east-1")
+)
 app.synth()

--- a/osdp/cdk.json
+++ b/osdp/cdk.json
@@ -15,7 +15,8 @@
     ]
   },
   "context": {
-    "collection_url": "https://api.dc.library.northwestern.edu/api/v2/collections/819526ed-985c-4f8f-a5c8-631fc400c2f1?as=iiif",
+    "collection_url": "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif",
+    "embedding_model_arn": "arn:aws:bedrock:us-east-1::foundation-model/cohere.embed-multilingual-v3",
     "manifest_fetch_concurrency": 15,
     "tags": {
       "project": "imls-grant"

--- a/osdp/constructs/db_construct.py
+++ b/osdp/constructs/db_construct.py
@@ -1,0 +1,268 @@
+from aws_cdk import (
+    CfnOutput,
+    RemovalPolicy,
+)
+from aws_cdk import (
+    aws_ec2 as ec2,
+)
+from aws_cdk import (
+    aws_iam as iam,
+)
+from aws_cdk import (
+    aws_rds as rds,
+)
+from aws_cdk import (
+    aws_secretsmanager as secretsmanager,
+)
+from aws_cdk import (
+    custom_resources as cr,
+)
+
+from constructs import Construct
+
+
+class DatabaseConstruct(Construct):
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        # Use the default VPC
+        vpc = ec2.Vpc.from_lookup(self, "DefaultVPC", is_default=True)
+
+        # Create security group for the Aurora cluster
+        db_security_group = ec2.SecurityGroup(
+            self,
+            "OsdpDatabaseSecurityGroup",
+            vpc=vpc,
+            description="Security group for OSDP Aurora PostgreSQL cluster",
+            allow_all_outbound=False,
+        )
+
+        # Add necessary inbound rule for Bedrock
+        (
+            db_security_group.add_ingress_rule(
+                peer=ec2.Peer.ipv4(vpc.vpc_cidr_block),
+                connection=ec2.Port.tcp(5432),
+                description="Allow Bedrock to connect to PostgreSQL",
+            ),
+        )
+
+        # Create database credentials in Secrets Manager
+        self.db_credentials = secretsmanager.Secret(
+            self,
+            "OsdpDBCredentials",
+            generate_secret_string=secretsmanager.SecretStringGenerator(
+                secret_string_template='{"username": "postgres"}',
+                generate_string_key="password",
+                exclude_characters='"@/\\',
+            ),
+        )
+
+        # Create Aurora Serverless v2 cluster
+        self.db_cluster = rds.DatabaseCluster(
+            self,
+            "OsdpKnowledgeBaseDB",
+            engine=rds.DatabaseClusterEngine.aurora_postgres(
+                version=rds.AuroraPostgresEngineVersion.VER_15_3  # Version?
+            ),
+            writer=rds.ClusterInstance.serverless_v2("Writer"),
+            vpc=vpc,
+            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
+            security_groups=[db_security_group],
+            credentials=rds.Credentials.from_secret(self.db_credentials),
+            removal_policy=RemovalPolicy.DESTROY,  # TODO Change this for production
+            serverless_v2_min_capacity=0.5,  # Minimum ACU (Aurora Capacity Units)
+            serverless_v2_max_capacity=1,  # Maximum ACU for dev
+            enable_data_api=True,
+        )
+
+        # Configure the cluster for Bedrock
+        db_init = cr.AwsCustomResource(
+            self,
+            "DBInit",
+            on_create=cr.AwsSdkCall(
+                service="RDSDataService",
+                action="executeStatement",
+                parameters={
+                    "secretArn": self.db_credentials.secret_arn,
+                    "database": "postgres",
+                    "resourceArn": self.db_cluster.cluster_arn,
+                    # Split into separate statements for better error handling
+                    "sql": """
+                        CREATE EXTENSION IF NOT EXISTS vector;
+                    """,
+                },
+                physical_resource_id=cr.PhysicalResourceId.of("DBInit-1"),
+            ),
+            policy=cr.AwsCustomResourcePolicy.from_statements(
+                [
+                    iam.PolicyStatement(actions=["rds-data:ExecuteStatement"], resources=[self.db_cluster.cluster_arn]),
+                    iam.PolicyStatement(
+                        actions=["secretsmanager:GetSecretValue"], resources=[self.db_credentials.secret_arn]
+                    ),
+                ]
+            ),
+        )
+
+        # Create schema
+        db_init2_schema = cr.AwsCustomResource(
+            self,
+            "DBInit2Schema",
+            on_create=cr.AwsSdkCall(
+                service="RDSDataService",
+                action="executeStatement",
+                parameters={
+                    "secretArn": self.db_credentials.secret_arn,
+                    "database": "postgres",
+                    "resourceArn": self.db_cluster.cluster_arn,
+                    "sql": "CREATE SCHEMA IF NOT EXISTS bedrock_integration;",
+                },
+                physical_resource_id=cr.PhysicalResourceId.of("DBInit-2-Schema"),
+            ),
+            policy=cr.AwsCustomResourcePolicy.from_statements(
+                [
+                    iam.PolicyStatement(actions=["rds-data:ExecuteStatement"], resources=[self.db_cluster.cluster_arn]),
+                    iam.PolicyStatement(
+                        actions=["secretsmanager:GetSecretValue"], resources=[self.db_credentials.secret_arn]
+                    ),
+                ]
+            ),
+        )
+
+        # Create role with password
+        db_password = self.db_credentials.secret_value_from_json("password").unsafe_unwrap()
+
+        db_init2_role = cr.AwsCustomResource(
+            self,
+            "DBInit2Role",
+            on_create=cr.AwsSdkCall(
+                service="RDSDataService",
+                action="executeStatement",
+                parameters={
+                    "secretArn": self.db_credentials.secret_arn,
+                    "database": "postgres",
+                    "resourceArn": self.db_cluster.cluster_arn,
+                    "sql": f"""
+                                    DO $$ 
+                                    BEGIN 
+                                        CREATE ROLE bedrock_user WITH LOGIN PASSWORD '{db_password}'; 
+                                    EXCEPTION WHEN duplicate_object THEN 
+                                        RAISE NOTICE 'Role already exists'; 
+                                    END $$;
+                                """,
+                },
+                physical_resource_id=cr.PhysicalResourceId.of("DBInit-2-Role"),
+            ),
+            policy=cr.AwsCustomResourcePolicy.from_statements(
+                [
+                    iam.PolicyStatement(actions=["rds-data:ExecuteStatement"], resources=[self.db_cluster.cluster_arn]),
+                    iam.PolicyStatement(
+                        actions=["secretsmanager:GetSecretValue"], resources=[self.db_credentials.secret_arn]
+                    ),
+                ]
+            ),
+        )
+
+        # Grant permissions
+        db_init2_grant = cr.AwsCustomResource(
+            self,
+            "DBInit2Grant",
+            on_create=cr.AwsSdkCall(
+                service="RDSDataService",
+                action="executeStatement",
+                parameters={
+                    "secretArn": self.db_credentials.secret_arn,
+                    "database": "postgres",
+                    "resourceArn": self.db_cluster.cluster_arn,
+                    "sql": "GRANT ALL ON SCHEMA bedrock_integration TO bedrock_user;",
+                },
+                physical_resource_id=cr.PhysicalResourceId.of("DBInit-2-Grant"),
+            ),
+            policy=cr.AwsCustomResourcePolicy.from_statements(
+                [
+                    iam.PolicyStatement(actions=["rds-data:ExecuteStatement"], resources=[self.db_cluster.cluster_arn]),
+                    iam.PolicyStatement(
+                        actions=["secretsmanager:GetSecretValue"], resources=[self.db_credentials.secret_arn]
+                    ),
+                ]
+            ),
+        )
+
+        # Add dependencies
+        db_init2_schema.node.add_dependency(db_init)
+        db_init2_role.node.add_dependency(db_init2_schema)
+        db_init2_grant.node.add_dependency(db_init2_role)
+
+        # Create table and index
+
+        # Create table
+        db_init3_table = cr.AwsCustomResource(
+            self,
+            "DBInit3Table",
+            on_create=cr.AwsSdkCall(
+                service="RDSDataService",
+                action="executeStatement",
+                parameters={
+                    "secretArn": self.db_credentials.secret_arn,
+                    "database": "postgres",
+                    "resourceArn": self.db_cluster.cluster_arn,
+                    "sql": """
+                        CREATE TABLE IF NOT EXISTS bedrock_integration.bedrock_knowledge_base (
+                            id uuid PRIMARY KEY,
+                            embedding vector(1024),
+                            chunks text,
+                            metadata jsonb
+                        );
+                    """,
+                },
+                physical_resource_id=cr.PhysicalResourceId.of("DBInit-3-Table"),
+            ),
+            policy=cr.AwsCustomResourcePolicy.from_statements(
+                [
+                    iam.PolicyStatement(actions=["rds-data:ExecuteStatement"], resources=[self.db_cluster.cluster_arn]),
+                    iam.PolicyStatement(
+                        actions=["secretsmanager:GetSecretValue"], resources=[self.db_credentials.secret_arn]
+                    ),
+                ]
+            ),
+        )
+
+        # Create index
+        self.db_init3_index = cr.AwsCustomResource(
+            self,
+            "DBInit3Index",
+            on_create=cr.AwsSdkCall(
+                service="RDSDataService",
+                action="executeStatement",
+                parameters={
+                    "secretArn": self.db_credentials.secret_arn,
+                    "database": "postgres",
+                    "resourceArn": self.db_cluster.cluster_arn,
+                    "sql": """
+                        CREATE INDEX IF NOT EXISTS embedding_idx ON bedrock_integration.bedrock_knowledge_base 
+                            USING ivfflat (embedding vector_l2_ops);
+                    """,
+                },
+                physical_resource_id=cr.PhysicalResourceId.of("DBInit-3-Index"),
+            ),
+            policy=cr.AwsCustomResourcePolicy.from_statements(
+                [
+                    iam.PolicyStatement(actions=["rds-data:ExecuteStatement"], resources=[self.db_cluster.cluster_arn]),
+                    iam.PolicyStatement(
+                        actions=["secretsmanager:GetSecretValue"], resources=[self.db_credentials.secret_arn]
+                    ),
+                ]
+            ),
+        )
+
+        # Add dependencies to ensure proper order
+        db_init3_table.node.add_dependency(db_init2_grant)
+        self.db_init3_index.node.add_dependency(db_init3_table)
+
+        # Ensure proper dependency order
+        db_init.node.add_dependency(self.db_cluster)
+
+        CfnOutput(self, "DatabaseClusterArn", value=self.db_cluster.cluster_arn)
+        CfnOutput(self, "DatabaseClusterIdentifier", value=self.db_cluster.cluster_identifier)
+        CfnOutput(self, "DatabaseEndpoint", value=self.db_cluster.cluster_endpoint.hostname)
+        CfnOutput(self, "DatabasePort", value=str(self.db_cluster.cluster_endpoint.port))
+        CfnOutput(self, "DatabaseSecretArn", value=self.db_credentials.secret_arn)

--- a/osdp/constructs/knowledge_base_construct.py
+++ b/osdp/constructs/knowledge_base_construct.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+from aws_cdk import CfnOutput
+from aws_cdk import aws_bedrock as bedrock
+from aws_cdk import aws_iam as iam
+from aws_cdk import custom_resources as cr
+
+from constructs import Construct
+
+
+class KnowledgeBaseConstruct(Construct):
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        *,
+        data_bucket: str,
+        db_cluster: str,
+        db_credentials: str,
+        embedding_model_arn: str,
+        stack_prefix: str,
+        step_function_trigger: str,
+        db_initialization: str,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        # Create IAM role for the Knowledge Base
+        kb_role = iam.Role(
+            self,
+            "OsdpBedrockKBRole",
+            assumed_by=iam.ServicePrincipal("bedrock.amazonaws.com"),
+            description="IAM role for OSDP Bedrock Knowledge Base",
+        )
+
+        # Policy for S3 data source
+        kb_role.add_to_policy(
+            iam.PolicyStatement(
+                sid="AllowS3Read",
+                effect=iam.Effect.ALLOW,
+                actions=["s3:*"],
+                resources=[
+                    data_bucket.bucket_arn,
+                    data_bucket.arn_for_objects("*"),
+                    data_bucket.arn_for_objects("iiif/*"),
+                ],
+            )
+        )
+
+        # RDS cluster policy for knowledgebase
+        kb_role.add_to_policy(
+            iam.PolicyStatement(actions=["rds:DescribeDBClusters"], resources=[db_cluster.cluster_arn])
+        )
+
+        # RDS data API policy for knowledgebase
+        kb_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "rds-data:ExecuteStatement",
+                    "rds-data:BatchExecuteStatement",
+                ],
+                resources=[db_cluster.cluster_arn],
+            )
+        )
+
+        # Bedrock foundation model policy for knowledge base
+        kb_role.add_to_policy(iam.PolicyStatement(actions=["bedrock:InvokeModel"], resources=[embedding_model_arn]))
+
+        # Secrets policy for knowldge base
+        kb_role.add_to_policy(
+            iam.PolicyStatement(actions=["secretsmanager:GetSecretValue"], resources=[db_credentials.secret_arn])
+        )
+
+        # Create the Knowledge Base
+        knowledge_base = bedrock.CfnKnowledgeBase(
+            self,
+            "OsdpBedrockKB",
+            name=f"{stack_prefix}-osdp-knowledge-base",
+            role_arn=kb_role.role_arn,
+            description="Knowledge base with S3 data source and Aurora PostgreSQL vector store",
+            knowledge_base_configuration=bedrock.CfnKnowledgeBase.KnowledgeBaseConfigurationProperty(
+                type="VECTOR",
+                vector_knowledge_base_configuration=bedrock.CfnKnowledgeBase.VectorKnowledgeBaseConfigurationProperty(
+                    embedding_model_arn=embedding_model_arn,
+                ),
+            ),
+            # Storage Configuration (Aurora PostgreSQL)
+            storage_configuration=bedrock.CfnKnowledgeBase.StorageConfigurationProperty(
+                type="RDS",
+                rds_configuration=bedrock.CfnKnowledgeBase.RdsConfigurationProperty(
+                    credentials_secret_arn=db_credentials.secret_arn,
+                    database_name="postgres",
+                    resource_arn=db_cluster.cluster_arn,
+                    table_name="bedrock_integration.bedrock_knowledge_base",
+                    field_mapping=bedrock.CfnKnowledgeBase.RdsFieldMappingProperty(
+                        metadata_field="metadata", primary_key_field="id", text_field="chunks", vector_field="embedding"
+                    ),
+                ),
+            ),
+        )
+
+        s3_data_source = bedrock.CfnDataSource(
+            self,
+            "MyCfnDataSource",
+            data_source_configuration=bedrock.CfnDataSource.DataSourceConfigurationProperty(
+                type="S3",
+                s3_configuration=bedrock.CfnDataSource.S3DataSourceConfigurationProperty(
+                    bucket_arn=data_bucket.bucket_arn, inclusion_prefixes=["iiif/"]
+                ),
+            ),
+            name="OsdpS3DataSource",
+            knowledge_base_id=knowledge_base.attr_knowledge_base_id,
+            description="OSDP S3 Data Source",
+            vector_ingestion_configuration=bedrock.CfnDataSource.VectorIngestionConfigurationProperty(
+                chunking_configuration=bedrock.CfnDataSource.ChunkingConfigurationProperty(
+                    chunking_strategy="FIXED_SIZE",
+                    fixed_size_chunking_configuration=bedrock.CfnDataSource.FixedSizeChunkingConfigurationProperty(
+                        max_tokens=300, overlap_percentage=20
+                    ),
+                )
+            ),
+        )
+
+        s3_data_source.node.add_dependency(knowledge_base)
+        knowledge_base.node.add_dependency(kb_role)
+        knowledge_base.node.add_dependency(db_cluster)
+        knowledge_base.node.add_dependency(db_credentials)
+        knowledge_base.node.add_dependency(db_initialization)  # Add this dependency
+
+        ingestion_job = cr.AwsCustomResource(
+            self,
+            "InitialIngestion",
+            on_create=cr.AwsSdkCall(
+                service="bedrock-agent",
+                action="startIngestionJob",
+                parameters={
+                    "dataSourceId": s3_data_source.attr_data_source_id,
+                    "knowledgeBaseId": knowledge_base.attr_knowledge_base_id,
+                    "name": "InitialSync",
+                    "description": "Initial sync of S3 data to Knowledge Base",
+                },
+                physical_resource_id=cr.PhysicalResourceId.of("InitialIngestion"),
+            ),
+            policy=cr.AwsCustomResourcePolicy.from_statements(
+                [iam.PolicyStatement(actions=["bedrock:StartIngestionJob"], resources=["*"])]
+            ),
+        )
+
+        ingestion_job.node.add_dependency(s3_data_source)
+        ingestion_job.node.add_dependency(knowledge_base)
+        ingestion_job.node.add_dependency(step_function_trigger)
+
+        CfnOutput(self, "KnowledgeBaseId", value=knowledge_base.attr_knowledge_base_id)
+        CfnOutput(self, "KnowledgeBaseRoleArn", value=kb_role.role_arn)

--- a/osdp/pipeline/osdp_application_stage.py
+++ b/osdp/pipeline/osdp_application_stage.py
@@ -6,7 +6,7 @@ from stacks.osdp_prototype_stack import OsdpPrototypeStack
 
 
 class OsdpApplicationStage(Stage):
-    def __init__(self, scope: Construct, id: str, **kwargs):
+    def __init__(self, scope: Construct, id: str, stack_prefix: str, **kwargs):
         super().__init__(scope, id, **kwargs)
 
         github_action_arn = f"arn:aws:iam::{self.account}:oidc-provider/token.actions.githubusercontent.com"
@@ -16,4 +16,4 @@ class OsdpApplicationStage(Stage):
             conditions={"StringLike": {"token.actions.githubusercontent.com:sub": "repo:nulib/osdp-prototype-ui:*"}},
         )
 
-        OsdpPrototypeStack(self, "OSDP-Prototype", ui_function_invoke_principal=principal)
+        OsdpPrototypeStack(self, "OSDP-Prototype", stack_prefix=stack_prefix, ui_function_invoke_principal=principal)

--- a/osdp/pipeline/pipeline_stack.py
+++ b/osdp/pipeline/pipeline_stack.py
@@ -7,7 +7,7 @@ from pipeline.osdp_application_stage import OsdpApplicationStage
 
 
 class PipelineStack(cdk.Stack):
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, stack_prefix: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         # Define the CodePipeline source
@@ -30,7 +30,7 @@ class PipelineStack(cdk.Stack):
                 "npm install",
                 "cd ../../",
                 "cdk --version",
-                "cdk synth -c stack_prefix=staging",
+                f"cdk synth -c stack_prefix={stack_prefix}",
             ],
             primary_output_directory="osdp/cdk.out",
         )
@@ -75,6 +75,6 @@ class PipelineStack(cdk.Stack):
 
         # Define the application stages
         deploy_stage = OsdpApplicationStage(
-            self, "staging", env=cdk.Environment(account="625046682746", region="us-east-1")
+            self, "staging", stack_prefix=stack_prefix, env=cdk.Environment(account="625046682746", region="us-east-1")
         )
         pipeline.add_stage(deploy_stage)

--- a/osdp/requirements.txt
+++ b/osdp/requirements.txt
@@ -1,3 +1,4 @@
 aws-cdk-lib==2.179.0
 constructs>=10.0.0,<11.0.0
 aws-cdk.aws-amplify-alpha==2.178.2a0
+boto3>=1.28.0

--- a/osdp/tests/unit/test_database.py
+++ b/osdp/tests/unit/test_database.py
@@ -1,0 +1,65 @@
+import aws_cdk as core
+import aws_cdk.assertions as assertions
+import pytest
+
+from stacks.osdp_prototype_stack import OsdpPrototypeStack
+
+
+@pytest.fixture
+def stack_and_template():
+    app = core.App()
+    app.node.set_context("stack_prefix", "alice")
+    app.node.set_context("tags", {"foo": "bar", "environment": "dev"})
+    app.node.set_context("collection_url", "http://example.com")
+    app.node.set_context(
+        "embedding_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
+    )
+    app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
+    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
+    template = assertions.Template.from_stack(stack)
+    return stack, template
+
+
+def test_aurora_cluster_created(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::RDS::DBCluster",
+        {
+            "Engine": "aurora-postgresql",
+            "EngineVersion": assertions.Match.string_like_regexp("15.3"),
+            "ServerlessV2ScalingConfiguration": {"MinCapacity": 0.5, "MaxCapacity": 1},
+            "EnableHttpEndpoint": True,
+        },
+    )
+
+
+def test_db_security_group_created(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::EC2::SecurityGroup",
+        {
+            "GroupDescription": assertions.Match.string_like_regexp(".*OSDP.*PostgreSQL.*"),
+            "SecurityGroupIngress": [
+                {
+                    "FromPort": 5432,
+                    "ToPort": 5432,
+                    "IpProtocol": "tcp",
+                    "Description": assertions.Match.string_like_regexp(".*Bedrock.*"),
+                }
+            ],
+        },
+    )
+
+
+def test_db_credentials_created(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::SecretsManager::Secret",
+        {
+            "GenerateSecretString": {
+                "SecretStringTemplate": '{"username": "postgres"}',
+                "GenerateStringKey": "password",
+                "ExcludeCharacters": '"@/\\',
+            }
+        },
+    )

--- a/osdp/tests/unit/test_knowledge_base.py
+++ b/osdp/tests/unit/test_knowledge_base.py
@@ -1,0 +1,79 @@
+import aws_cdk as core
+import aws_cdk.assertions as assertions
+import pytest
+
+from stacks.osdp_prototype_stack import OsdpPrototypeStack
+
+
+@pytest.fixture
+def stack_and_template():
+    app = core.App()
+    app.node.set_context("stack_prefix", "alice")
+    app.node.set_context("tags", {"foo": "bar", "environment": "dev"})
+    app.node.set_context("collection_url", "http://example.com")
+    app.node.set_context(
+        "embedding_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
+    )
+    app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
+    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
+    template = assertions.Template.from_stack(stack)
+    return stack, template
+
+
+def test_knowledge_base_outputs(stack_and_template):
+    stack, template = stack_and_template
+
+    # Get ALL outputs
+    all_outputs = template.find_outputs("*")
+    print("All outputs:", list(all_outputs.keys()))
+
+    # Filter manually
+    kb_id_outputs = [k for k in all_outputs.keys() if "KnowledgeBaseId" in k]
+    kb_role_outputs = [k for k in all_outputs.keys() if "KnowledgeBaseRoleArn" in k]
+
+    print("ID outputs found:", kb_id_outputs)
+    print("Role outputs found:", kb_role_outputs)
+
+    assert len(kb_id_outputs) > 0, "No KnowledgeBaseId output found"
+    assert len(kb_role_outputs) > 0, "No KnowledgeBaseRoleArn output found"
+
+
+def test_knowledge_base_resource_created(stack_and_template):
+    stack, template = stack_and_template
+    # Assuming you're using a CfnKnowledgeBase resource in your construct, check that there's exactly one.
+    template.resource_count_is("AWS::Bedrock::KnowledgeBase", 1)
+
+
+def test_data_source_created(stack_and_template):
+    stack, template = stack_and_template
+    # Check for your S3 data source resource with the expected Name and Description
+    template.has_resource_properties(
+        "AWS::Bedrock::DataSource", {"Name": "OsdpS3DataSource", "Description": "OSDP S3 Data Source"}
+    )
+
+
+def test_ingestion_custom_resource_exists(stack_and_template):
+    stack, template = stack_and_template
+
+    # Get all Custom::AWS resources
+    custom_resources = template.find_resources("Custom::AWS")
+
+    # Look for a resource that matches our bedrock ingestion job
+    found_ingestion_job = False
+    for _resource_id, resource in custom_resources.items():
+        resource_str = str(resource)  # Convert to string for easier searching
+
+        # Check for key characteristics of our ingestion job
+        if all(
+            marker in resource_str
+            for marker in [
+                "bedrock-agent",
+                "startIngestionJob",
+                "InitialSync",  # The name parameter
+                "knowledgeBaseId",
+            ]
+        ):
+            found_ingestion_job = True
+            break
+
+    assert found_ingestion_job, "No ingestion job custom resource found"

--- a/osdp/tests/unit/test_source_stack.py
+++ b/osdp/tests/unit/test_source_stack.py
@@ -9,10 +9,12 @@ from stacks.osdp_prototype_stack import OsdpPrototypeStack
 @pytest.fixture
 def stack_and_template():
     app = core.App()
-    # Set context values on the app's node
     app.node.set_context("stack_prefix", "alice")
     app.node.set_context("tags", {"foo": "bar", "environment": "dev"})
     app.node.set_context("collection_url", "http://example.com")
+    app.node.set_context(
+        "embedding_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
+    )
     app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
     stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
@@ -106,6 +108,9 @@ def test_function_invoker_role_created():
     app.node.set_context("stack_prefix", "alice")
     app.node.set_context("tags", {"foo": "bar", "environment": "dev"})
     app.node.set_context("collection_url", "http://example.com")
+    app.node.set_context(
+        "embedding_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
+    )
     app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
     github_action_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
     principal = iam.WebIdentityPrincipal(


### PR DESCRIPTION
### Summary of Changes

- Adds + configures Aurora Serverless DB cluster
- Adds + configures Bedrock Knowledgebase with S3 data source (manifests bucket)
- Runs initial data sync for Knowledgebase


### Steps to Test
- `aws sso login` (staging admin)
- `cd osdp`
- `cdk deploy prefix-OSDP-Prototype` (Replace the "prefix" w/your dev prefix")
- Check in CloudFormation for stack to build (will take some time)
- Check for Knowledgebase w/S3 data source, Aurora cluster)
- End result you should have records w/embeddings in your Aurora database table (`bedrock_integration.bedrock_knowledge_base`)

#### Cleanup
- `cdk destroy prefix-OSDP-Prototype` (or delete from CloudFormation)