### PR TITLE
Basic chat endpoint and API with Cognito auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 node_modules/
 .venv
 .ruff_cache
+.vscode/

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Since the `cdk.json` file is generally committed to source control, it should ge
 
 #### Required context values
 
-- `stack_prefix` (str) - will be appended to the beginning of the CloudFormation stack on deploy. (*For NU devs this is not required, it will use the `DEV_PREFIX` env var in AWS.)
+- `stack_prefix` (str) - will be appended to the beginning of the CloudFormation stack on deploy. (*For NU devs this is not needed, it will use the `DEV_PREFIX` env var in AWS.)
 - `collection_url` (str)- the url of the IIIF collection to load during deployment. There is a small collection (6 items) in the `cdk.json` file, but you will want to change or override on the command line.
 - `embedding_model_arn` (str) - Embedding model to use for Bedrock Knowledgebase
+- `foundation_model_arn` (str) - Foundation model to use for Bedrock RetreiveAndGenerate invocations
 
 #### Optional context values
 
@@ -84,30 +85,10 @@ Since the `cdk.json` file is generally committed to source control, it should ge
     },
 ```
 - `manifest_fetch_url` (str) - The concurrency to use when retrieving IIIF manifests from your API. If not provided, the default will be used (2).
-- `amplify.auth.secret_name` (str) - The name of the AWS Secrets Manager secret used for authentication. **To disable auth, use the `NO_AUTH` keyword**
-- `amplify.auth.username_key` (str) - The key for the username field within the secret (default: "username").
-- `amplify.auth.password_key` (str) - The key for the password field within the secret (default: "password").
 
 ```bash
 # use default secret name (`OSDPSecrets`)
 cdk deploy
-
-# use NO_AUTH keyword to disable auth
-cdk deploy -c amplify.auth.secret_name=NO_AUTH
-
-# use altername secret name with default username and password key
-cdk deploy -c amplify.auth.secret_name=MySecretName
-
-# use custom values
-cdk deploy \
-  -c amplify.auth.secret_name=MySecret \
-  -c amplify.auth.username_key=myUserKey \
-  -c amplify.auth.password_key=myPassKey
-```
-
-> [!IMPORTANT]
-> If a secret amplify.auth.secret_name is provided, it must be present in Secrets Manager or the app will not deploy
-
 
 #### Providing context values on the command line
 

--- a/osdp/cdk.json
+++ b/osdp/cdk.json
@@ -17,7 +17,7 @@
   "context": {
     "collection_url": "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif",
     "embedding_model_arn": "arn:aws:bedrock:us-east-1::foundation-model/cohere.embed-multilingual-v3",
-    "foundation_model_arn": "arn:aws:bedrock:us-east-1:625046682746:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "foundation_model_arn": "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
     "manifest_fetch_concurrency": 15,
     "tags": {
       "project": "imls-grant"

--- a/osdp/cdk.json
+++ b/osdp/cdk.json
@@ -17,6 +17,7 @@
   "context": {
     "collection_url": "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif",
     "embedding_model_arn": "arn:aws:bedrock:us-east-1::foundation-model/cohere.embed-multilingual-v3",
+    "foundation_model_arn": "arn:aws:bedrock:us-east-1:625046682746:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
     "manifest_fetch_concurrency": 15,
     "tags": {
       "project": "imls-grant"

--- a/osdp/cdk.json
+++ b/osdp/cdk.json
@@ -17,7 +17,7 @@
   "context": {
     "collection_url": "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif",
     "embedding_model_arn": "arn:aws:bedrock:us-east-1::foundation-model/cohere.embed-multilingual-v3",
-    "foundation_model_arn": "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "foundation_model_arn": "arn:aws:bedrock:us-east-1:625046682746:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
     "manifest_fetch_concurrency": 15,
     "tags": {
       "project": "imls-grant"

--- a/osdp/constructs/api_construct.py
+++ b/osdp/constructs/api_construct.py
@@ -1,5 +1,17 @@
 from aws_cdk import (
     CfnOutput,
+    Duration,
+    RemovalPolicy,
+    Stack,
+)
+from aws_cdk import (
+    aws_apigateway as apigw,
+)
+from aws_cdk import (
+    aws_cognito as cognito,
+)
+from aws_cdk import (
+    aws_iam as iam,
 )
 from aws_cdk import (
     aws_lambda as _lambda,
@@ -9,36 +21,101 @@ from constructs import Construct
 
 
 class ApiConstruct(Construct):
-    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+    def __init__(
+        self, scope: Construct, id: str, knowledge_base: str, stack_prefix: str, model_arn: str, **kwargs
+    ) -> None:
         super().__init__(scope, id, **kwargs)
 
-        # Hello World Function
-        # This is a standin for our API at the moment
-        my_function = _lambda.Function(
+        # Create a Cognito User Pool
+        self.user_pool = cognito.UserPool(
             self,
-            "HelloWorldFunction",
-            runtime=_lambda.Runtime.NODEJS_20_X,  # Provide any supported Node.js runtime
+            "OSDPUsers",
+            user_pool_name="OSDPUsers",
+            self_sign_up_enabled=False,  # Only admin can create users
+            auto_verify={"email": True},
+            password_policy=cognito.PasswordPolicy(
+                min_length=8, require_lowercase=True, require_digits=True, require_symbols=True, require_uppercase=True
+            ),
+            sign_in_case_sensitive=False,
+            mfa=cognito.Mfa.OFF,
+            removal_policy=RemovalPolicy.DESTROY,
+        )
+
+        # Create a User Pool Client
+        self.user_pool_client = self.user_pool.add_client(
+            "OSDPClient",
+            user_pool_client_name="OSDPClient",
+            auth_flows={"user_password": True, "admin_user_password": True, "user_srp": True},
+            prevent_user_existence_errors=True,
+            enable_token_revocation=True,
+        )
+
+        # Create an Admin Group in the User Pool
+        _admin_group = cognito.CfnUserPoolGroup(
+            self, "AdminPoolGroup", user_pool_id=self.user_pool.user_pool_id, group_name="Admin"
+        )
+
+        # Stack outputs
+        CfnOutput(self, "UserPoolId", value=self.user_pool.user_pool_id)
+        CfnOutput(self, "UserPoolClientId", value=self.user_pool_client.user_pool_client_id)
+
+        # Create chat function integration
+        chat_function = _lambda.Function(
+            self,
+            "ChatFunction",
+            runtime=_lambda.Runtime.PYTHON_3_11,
             handler="index.handler",
-            code=_lambda.Code.from_inline(
-                """
-                exports.handler = async function(event) {
-                return {
-                    headers: {
-                        "Access-Control-Allow-Origin" : "*",
-                        "Access-Control-Allow-Credentials" : true
-                    },
-                    statusCode: 200,
-                    body: JSON.stringify('Hello World!'),
-                };
-                };
-                """
+            code=_lambda.Code.from_asset("./functions/chat"),
+            timeout=Duration.minutes(2),
+            environment={"KNOWLEDGE_BASE_ID": knowledge_base.attr_knowledge_base_id, "MODEL_ARN": model_arn},
+        )
+
+        chat_function.node.add_dependency(knowledge_base)
+
+        self.region = Stack.of(self).region
+        self.account = Stack.of(self).account
+
+        # Add Bedrock permissions
+        chat_function.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "bedrock:InvokeModel",
+                    "bedrock:Retrieve",
+                    "bedrock:RetrieveAndGenerate",
+                    "bedrock:GetInferenceProfile",
+                ],
+                resources=[  # TODO - scope these better
+                    model_arn,
+                    f"arn:aws:bedrock:{self.region}:{self.account}:model/*",
+                    f"arn:aws:bedrock:{self.region}:{self.account}:knowledge-base/*",
+                    f"arn:aws:bedrock:{self.region}:{self.account}:inference-profile/*",
+                    "arn:aws:bedrock:*:*:foundation-model/*",
+                ],
+            )
+        )
+
+        # Create Cognito Authorizer
+        auth = apigw.CognitoUserPoolsAuthorizer(self, "ChatAuthorizer", cognito_user_pools=[self.user_pool])
+
+        # Create API Gateway
+        self.api = apigw.RestApi(
+            self,
+            "OSDPApi",
+            rest_api_name=f"{stack_prefix}-OSDP-API",
+            default_cors_preflight_options=apigw.CorsOptions(
+                allow_origins=["*"], allow_methods=["POST"], allow_headers=["*"]
             ),
         )
 
-        # Define the Lambda function URL resource
-        self.api_url = my_function.add_function_url(
-            auth_type=_lambda.FunctionUrlAuthType.AWS_IAM,
+        # Add /chat route with Cognito authorization
+        chat_integration = apigw.LambdaIntegration(chat_function)
+        chat_resource = self.api.root.add_resource("chat")
+        chat_resource.add_method(
+            "POST", chat_integration, authorizer=auth, authorization_type=apigw.AuthorizationType.COGNITO
         )
 
-        # Define a CloudFormation output for your URL
-        CfnOutput(self, "apiUrlOutput", value=self.api_url.url)
+        self.api.node.add_dependency(self.user_pool)
+        self.api.node.add_dependency(knowledge_base)
+
+        # Add API Gateway URL to outputs
+        CfnOutput(self, "ApiUrl", value=self.api.url)

--- a/osdp/constructs/ui_construct.py
+++ b/osdp/constructs/ui_construct.py
@@ -1,71 +1,14 @@
 # ui_construct.py
 from typing import Optional
 
-from aws_cdk import App, BundlingFileAccess, BundlingOptions, CfnOutput, Duration, Fn, Size, Stack, triggers
+from aws_cdk import BundlingFileAccess, BundlingOptions, CfnOutput, Duration, Fn, Size, Stack, triggers
 from aws_cdk import aws_amplify_alpha as amplify
 from aws_cdk import aws_iam as iam
 from aws_cdk import (
     aws_lambda as _lambda,
 )
-from aws_cdk import aws_secretsmanager as secretsmanager
 
 from constructs import Construct
-
-
-class AmplifyAuthContext:
-    """
-    Holds Amplify authentication context values from the CDK application.
-
-    This class retrieves optional authentication-related context values from the CDK context,
-    either from `cdk.json` or CLI parameters.
-
-    Attributes
-    ----------
-    secret_name : Optional[str]
-        The name of the AWS Secrets Manager secret used for authentication (default: "OSDPSecrets").
-        Use `NO_AUTH` keyword to disable authentication.
-    username_key : str
-        The key for the username field within the secret (default: "username").
-    password_key : str
-        The key for the password field within the secret (default: "password").
-
-    Examples
-    --------
-    Pass context values using the CDK CLI:
-
-    ```
-    cdk deploy
-        -c amplify.auth.secret_name=MySecret
-        -c amplify.auth.username_key=myUserKey
-        -c amplify.auth.password_key=myPassKey
-    ```
-
-    If not provided, `username_key` and `password_key` default to `"username"` and `"password"`, respectively.
-
-    Parameters
-    ----------
-    app : App
-        The CDK App object from which to retrieve context values.
-    """
-
-    def __init__(self, app: App):
-        context_name = self._get_optional_context(app, "amplify.auth.secret_name")
-        self.secret_name: str = (
-            "OSDPSecrets" if context_name is None else (None if context_name == "NO_AUTH" else context_name)
-        )
-        self.username_key: str = self._get_optional_context(app, "amplify.auth.username_key") or "username"
-        self.password_key: str = self._get_optional_context(app, "amplify.auth.password_key") or "password"
-
-    @staticmethod
-    def _get_optional_context(app: App, key: str) -> Optional[str]:
-        """
-        Retrieve an optional context value from the CDK application.
-
-        :param app: The CDK App object.
-        :param key: The context key to retrieve.
-        :return: The context value if available, otherwise `None`.
-        """
-        return app.node.try_get_context(key) or None
 
 
 class UIConstruct(Construct):
@@ -86,7 +29,6 @@ class UIConstruct(Construct):
         id (str): The construct ID.
         stack_id (str): The unique ID for the stack.
         api_url (str): The URL of the API to be included in the UI build.
-        auth_context (AmplifyAuthContext): The authentication values for the UI retrieved from the CDK context.
         function_invoker_principal (Optional[iam.IPrincipal]): Principal that can invoke the build function.
     """
 
@@ -97,7 +39,9 @@ class UIConstruct(Construct):
         *,
         stack_id: str,
         api_url: str,
-        auth_context: AmplifyAuthContext,
+        cognito_user_pool: None,
+        cognito_user_pool_id: str,
+        cognito_user_pool_client_id: str,
         function_invoker_principal: Optional[iam.IPrincipal] = None,
         **kwargs,
     ) -> None:
@@ -106,23 +50,7 @@ class UIConstruct(Construct):
         stack = Stack.of(self)
         app_name = Fn.join("-", [stack.stack_name.lower(), "ui", stack_id])
         app_branch_name = "main"
-
-        if auth_context.secret_name:
-            secret = secretsmanager.Secret.from_secret_name_v2(
-                self,
-                "AmplifyAuthSecret",
-                secret_name=auth_context.secret_name,
-            )
-
-            username = secret.secret_value_from_json(auth_context.username_key).unsafe_unwrap()
-            password = secret.secret_value_from_json(auth_context.password_key)
-
-            basic_auth = amplify.BasicAuth(
-                username=username,
-                password=password,
-            )
-        else:
-            basic_auth = None
+        basic_auth = None
 
         self.amplify_app = amplify.App(
             self,
@@ -153,10 +81,12 @@ class UIConstruct(Construct):
             environment={
                 "REPO_NAME": "osdp-prototype-ui",
                 "NEXT_PUBLIC_API_URL": api_url,
+                "NEXT_PUBLIC_COGNITO_USER_POOL_ID": cognito_user_pool_id,
+                "NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID": cognito_user_pool_client_id,
                 "AMPLIFY_APP_ID": self.amplify_app.app_id,
                 "AMPLIFY_BRANCH_NAME": app_branch_name,
             },
-            timeout=Duration.minutes(5),  # TODO: Build times are nearing this limit
+            timeout=Duration.minutes(10),
             memory_size=1024,
             ephemeral_storage_size=Size.gibibytes(1),
             initial_policy=[
@@ -168,6 +98,7 @@ class UIConstruct(Construct):
                     ],
                 )
             ],
+            execute_on_handler_change=False,
         )
 
         # Add the Git layer to the build function
@@ -215,6 +146,7 @@ class UIConstruct(Construct):
             )
 
         self.build_function.node.add_dependency(self.amplify_app)
+        self.build_function.node.add_dependency(cognito_user_pool)
 
         CfnOutput(self, "buildFunctionUrl", value=self.build_function_url.url)
         CfnOutput(

--- a/osdp/functions/chat/index.py
+++ b/osdp/functions/chat/index.py
@@ -1,0 +1,55 @@
+import json
+import os
+
+import boto3
+
+bedrock_agent_runtime_client = boto3.client("bedrock-agent-runtime")
+
+
+def handler(event, _context):
+    print(event)
+    if not event.get("body") or event.get("body") == "":
+        return {"statusCode": 400}
+
+    request_body = json.loads(event.get("body"))
+    user_prompt = request_body.get("user_prompt")
+
+    if not user_prompt:
+        return {"statusCode": 400}
+
+    print(user_prompt)
+
+    knowledge_base_id = os.environ["KNOWLEDGE_BASE_ID"]
+    modelArn = os.environ["MODEL_ARN"]
+
+    prompt = f"""\n\nHuman:
+    Please answer [question] appropriately.
+    [question]
+    {user_prompt}
+    Assistant:
+    """
+
+    bedrock_response = bedrock_agent_runtime_client.retrieve_and_generate(
+        input={
+            "text": prompt,
+        },
+        retrieveAndGenerateConfiguration={
+            "type": "KNOWLEDGE_BASE",
+            "knowledgeBaseConfiguration": {
+                "knowledgeBaseId": knowledge_base_id,
+                "modelArn": modelArn,
+            },
+        },
+    )
+
+    print("Received response:" + json.dumps(bedrock_response, ensure_ascii=False))
+
+    response_output = bedrock_response["output"]["text"]
+
+    response = {"answer": response_output, "references": bedrock_response["citations"][0]["retrievedReferences"]}
+
+    return {
+        "headers": {"Access-Control-Allow-Origin": "*", "Access-Control-Allow-Credentials": True},
+        "statusCode": 200,
+        "body": json.dumps(response),
+    }

--- a/osdp/stacks/osdp_prototype_stack.py
+++ b/osdp/stacks/osdp_prototype_stack.py
@@ -17,7 +17,7 @@ from constructs.db_construct import DatabaseConstruct
 from constructs.ecs_task_construct import EcsConstruct
 from constructs.knowledge_base_construct import KnowledgeBaseConstruct
 from constructs.step_functions_construct import StepFunctionsConstruct
-from constructs.ui_construct import AmplifyAuthContext, UIConstruct
+from constructs.ui_construct import UIConstruct
 
 ECR_IMAGE = "public.ecr.aws/nulib-staging/osdp-iiif-fetcher:latest"
 
@@ -44,19 +44,6 @@ class OsdpPrototypeStack(Stack):
         unique_id = Fn.select(2, Fn.split("/", self.stack_id))
         suffix = Fn.select(4, Fn.split("-", unique_id))
 
-        # Create the API
-        self.api_construct = ApiConstruct(self, "ApiConstruct")
-
-        # Create the UI
-        self.ui_construct = UIConstruct(
-            self,
-            "UIConstruct",
-            stack_id=suffix,
-            api_url=self.api_construct.api_url.url,
-            auth_context=AmplifyAuthContext(self),
-            function_invoker_principal=ui_function_invoke_principal,
-        )
-
         # S3 bucket for the IIIF Manifests (and other data)
         data_bucket_name = Fn.join("-", [self.stack_name.lower(), suffix])
 
@@ -73,23 +60,15 @@ class OsdpPrototypeStack(Stack):
             removal_policy=RemovalPolicy.DESTROY,
             auto_delete_objects=True,
         )
+
         # Instantiate the ECS construct
         ecs_construct = EcsConstruct(self, "EcsConstruct", data_bucket=data_bucket, ecr_image=ECR_IMAGE)
-
-        # Instantiate the Step Functions construct
-        step_functions_construct = StepFunctionsConstruct(
-            self,
-            "StepFunctionsConstruct",
-            ecs_construct=ecs_construct,
-            data_bucket=data_bucket,
-            collection_url=self.node.try_get_context("collection_url"),
-        )
 
         # Database construct
         database_construct = DatabaseConstruct(self, "DatabaseConstruct")
 
         # Knowledge Base construct
-        _knowledge_base_construct = KnowledgeBaseConstruct(
+        knowledge_base_construct = KnowledgeBaseConstruct(
             self,
             "KnowledgeBaseConstruct",
             data_bucket=data_bucket,
@@ -97,6 +76,40 @@ class OsdpPrototypeStack(Stack):
             db_cluster=database_construct.db_cluster,
             db_credentials=database_construct.db_credentials,
             stack_prefix=stack_prefix,
-            step_function_trigger=step_functions_construct.step_function_trigger,
             db_initialization=database_construct.db_init3_index,
+        )
+
+        # Create the API
+        self.api_construct = ApiConstruct(
+            self,
+            "ApiConstruct",
+            knowledge_base=knowledge_base_construct.knowledge_base,
+            stack_prefix=stack_prefix,
+            model_arn=self.node.try_get_context("foundation_model_arn"),
+        )
+
+        # Create the UI
+        self.ui_construct = UIConstruct(
+            self,
+            "UIConstruct",
+            stack_id=suffix,
+            api_url=self.api_construct.api.url,
+            cognito_user_pool=self.api_construct.user_pool,
+            cognito_user_pool_id=self.api_construct.user_pool.user_pool_id,
+            cognito_user_pool_client_id=self.api_construct.user_pool_client.user_pool_client_id,
+            function_invoker_principal=ui_function_invoke_principal,
+        )
+
+        # Instantiate the Step Functions construct
+        _step_functions_construct = StepFunctionsConstruct(
+            self,
+            "StepFunctionsConstruct",
+            ecs_construct=ecs_construct,
+            data_bucket=data_bucket,
+            collection_url=self.node.try_get_context("collection_url"),
+            knowledge_base=knowledge_base_construct.knowledge_base,  # Pass the actual construct
+            data_source=knowledge_base_construct.s3_data_source,  # If you expose this
+            db_cluster=database_construct.db_cluster,  # Pass DB cluster
+            knowledge_base_id=knowledge_base_construct.knowledge_base_id,
+            data_source_id=knowledge_base_construct.data_source_id,
         )

--- a/osdp/tests/unit/test_api.py
+++ b/osdp/tests/unit/test_api.py
@@ -1,0 +1,168 @@
+import aws_cdk as core
+import aws_cdk.assertions as assertions
+import pytest
+
+from stacks.osdp_prototype_stack import OsdpPrototypeStack
+
+
+@pytest.fixture
+def stack_and_template():
+    app = core.App()
+    app.node.set_context("stack_prefix", "alice")
+    app.node.set_context("tags", {"foo": "bar", "environment": "dev"})
+    app.node.set_context("collection_url", "http://example.com")
+    app.node.set_context(
+        "embedding_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
+    )
+    app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
+    stack = OsdpPrototypeStack(
+        app, "alice-OSDP-Prototype", stack_prefix="alice", env={"account": "123456789012", "region": "us-east-1"}
+    )
+    template = assertions.Template.from_stack(stack)
+    return stack, template
+
+
+def test_cognito_user_pool_created(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::Cognito::UserPool",
+        {
+            "UserPoolName": "OSDPUsers",
+            "AutoVerifiedAttributes": ["email"],  # Note: AutoVerifiedAttributes not AutoVerifyAttributes
+            "MfaConfiguration": "OFF",
+            "Policies": {
+                "PasswordPolicy": {
+                    "MinimumLength": 8,
+                    "RequireLowercase": True,
+                    "RequireNumbers": True,  # Note: RequireNumbers not RequireDigits
+                    "RequireSymbols": True,
+                    "RequireUppercase": True,
+                }
+            },
+            "AdminCreateUserConfig": {"AllowAdminCreateUserOnly": True},  # This replaces SelfSignUpEnabled: False
+        },
+    )
+
+
+def test_cognito_user_pool_client_created(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::Cognito::UserPoolClient",
+        {
+            "UserPoolId": assertions.Match.any_value(),
+            "ClientName": "OSDPClient",
+            "ExplicitAuthFlows": [
+                "ALLOW_USER_PASSWORD_AUTH",
+                "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+                "ALLOW_USER_SRP_AUTH",
+                "ALLOW_REFRESH_TOKEN_AUTH",  # This was missing in your original test
+            ],
+            "PreventUserExistenceErrors": "ENABLED",
+            "EnableTokenRevocation": True,
+        },
+    )
+
+
+def test_admin_group_created(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::Cognito::UserPoolGroup",
+        {
+            "GroupName": "Admin",
+            "UserPoolId": assertions.Match.any_value(),
+        },
+    )
+
+
+def test_chat_lambda_created(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Handler": "index.handler",
+            "Runtime": "python3.11",
+            "Timeout": 120,
+            "Environment": {
+                "Variables": {
+                    "KNOWLEDGE_BASE_ID": assertions.Match.any_value(),
+                    "MODEL_ARN": assertions.Match.any_value(),
+                }
+            },
+        },
+    )
+
+
+def test_api_gateway_created(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::ApiGateway::RestApi",
+        {
+            "Name": "alice-OSDP-API",
+        },
+    )
+
+
+def test_api_gateway_cors_configured(stack_and_template):
+    stack, template = stack_and_template
+    response_headers = {
+        "ResponseParameters": {
+            "method.response.header.Access-Control-Allow-Headers": assertions.Match.string_like_regexp(".*"),
+            "method.response.header.Access-Control-Allow-Methods": assertions.Match.string_like_regexp(".*POST.*"),
+            "method.response.header.Access-Control-Allow-Origin": "'*'",
+        }
+    }
+    template.has_resource_properties(
+        "AWS::ApiGateway::Method",
+        {
+            "HttpMethod": "OPTIONS",
+            "ResourceId": assertions.Match.any_value(),
+            "RestApiId": assertions.Match.any_value(),
+            "Integration": {
+                "IntegrationResponses": assertions.Match.array_with([assertions.Match.object_like(response_headers)]),
+            },
+        },
+    )
+
+
+def test_chat_endpoint_with_cognito_auth(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::ApiGateway::Method",
+        {
+            "HttpMethod": "POST",
+            "ResourceId": assertions.Match.any_value(),
+            "RestApiId": assertions.Match.any_value(),
+            "AuthorizationType": "COGNITO_USER_POOLS",
+            "AuthorizerId": assertions.Match.any_value(),
+            "Integration": {
+                "Type": "AWS_PROXY",
+                "IntegrationHttpMethod": "POST",
+            },
+        },
+    )
+
+
+def test_lambda_has_bedrock_permissions(stack_and_template):
+    stack, template = stack_and_template
+    template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": {
+                "Statement": assertions.Match.array_with(
+                    [
+                        assertions.Match.object_like(
+                            {
+                                "Action": [
+                                    "bedrock:InvokeModel",
+                                    "bedrock:Retrieve",
+                                    "bedrock:RetrieveAndGenerate",
+                                    "bedrock:GetInferenceProfile",
+                                ],
+                                "Effect": "Allow",
+                            }
+                        )
+                    ]
+                )
+            }
+        },
+    )

--- a/osdp/tests/unit/test_knowledge_base.py
+++ b/osdp/tests/unit/test_knowledge_base.py
@@ -42,40 +42,11 @@ def test_knowledge_base_outputs(stack_and_template):
 
 def test_knowledge_base_resource_created(stack_and_template):
     stack, template = stack_and_template
-    # Assuming you're using a CfnKnowledgeBase resource in your construct, check that there's exactly one.
     template.resource_count_is("AWS::Bedrock::KnowledgeBase", 1)
 
 
 def test_data_source_created(stack_and_template):
     stack, template = stack_and_template
-    # Check for your S3 data source resource with the expected Name and Description
     template.has_resource_properties(
         "AWS::Bedrock::DataSource", {"Name": "OsdpS3DataSource", "Description": "OSDP S3 Data Source"}
     )
-
-
-def test_ingestion_custom_resource_exists(stack_and_template):
-    stack, template = stack_and_template
-
-    # Get all Custom::AWS resources
-    custom_resources = template.find_resources("Custom::AWS")
-
-    # Look for a resource that matches our bedrock ingestion job
-    found_ingestion_job = False
-    for _resource_id, resource in custom_resources.items():
-        resource_str = str(resource)  # Convert to string for easier searching
-
-        # Check for key characteristics of our ingestion job
-        if all(
-            marker in resource_str
-            for marker in [
-                "bedrock-agent",
-                "startIngestionJob",
-                "InitialSync",  # The name parameter
-                "knowledgeBaseId",
-            ]
-        ):
-            found_ingestion_job = True
-            break
-
-    assert found_ingestion_job, "No ingestion job custom resource found"

--- a/osdp/tests/unit/test_source_stack.py
+++ b/osdp/tests/unit/test_source_stack.py
@@ -73,7 +73,7 @@ def test_build_function_created(stack_and_template):
             "Handler": "index.handler",
             "Runtime": "nodejs22.x",
             "Layers": ["arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:8"],
-            "Timeout": 300,
+            "Timeout": 600,
             "MemorySize": 1024,
             "EphemeralStorage": {"Size": 1024},
             "Environment": {


### PR DESCRIPTION
## Summary of Changes

- Adds API Gateway with (non-streaming) chat route with Cognito auth
- Rearranges execution order so that step function runs last and is responsible for the full data load including IIIF manifest download through KB data sync
- Removes basic auth from Amplify app in favor of Cognito auth (https://github.com/nulib/osdp-prototype-ui/pull/2)

## Steps to Test

#### Deploy the stack

- `aws sso login` (as `staging-admin`)
- `cdk deploy yourprefix-OSDP-Prototype`
- Wait for deploy to complete... 🕐 

#### Create Cognito User (note: you could also do all this in the AWS console)

-  From the list of outputs find & copy the User Pool id. It looks like: `*-OSDP-Prototype.ApiConstructUserPoolId*`
```
# Below replace with a unique username, and your email address and the correct Cognito User Pool Id

aws cognito-idp admin-create-user \
  --user-pool-id us-east-1_CX2XzUKpY \
  --username testuser \
  --temporary-password Test123! \
  --user-attributes Name=email,Value=karen.shaw@northwestern.edu
  ```

#### Set the Users Password

```
# Below replace with the Cognito User Pool Id and your unique username

aws cognito-idp admin-set-user-password \
  --user-pool-id us-east-1_CX2XzUKrY \
  --username testuser \
  --password YourNewPassword123! \
  --permanent
```

#### Obtain a Cognito Auth Token

- From the outputs grab the user pool client id. It looks like: `*-OSDP-Prototype.ApiConstructUserPoolClientId*A`
```
# Replace the client id and your unique username

aws cognito-idp initiate-auth \
  --auth-flow USER_PASSWORD_AUTH \
  --client-id 16erblbut90j008d98kkjdr550 \
  --auth-parameters USERNAME=testuser,PASSWORD=YourNewPassword123!
```

#### Invoke the Chat Endpoint

- From the previous response copy the `IdToken`
- From the outputs copy the `*-OSDP-Prototype.ApiConstructApiUrl*`
- Make a chat request (the collection that's loaded by default is Africa Embracing Obama)
```
# Replace API url and IdToken below

curl -X POST \
  'https://ontbb5vx5b.execute-api.us-east-1.amazonaws.com/prod/chat' \
  -H 'Authorization: COPYTHETOKENHERE' \
  -H 'Content-Type: application/json' \
  -d '{"user_prompt": "When was Barak Obama born?"}'
  ```


#### (Optional) Test from Front end

- See PR: https://github.com/nulib/osdp-prototype-ui/pull/2

![Screenshot 2025-02-27 at 7 02 16 AM](https://github.com/user-attachments/assets/cf728486-308a-4466-8d75-50147372dba4)


