### PR TITLE
Configure NU subdomain for staging amplify app

### DIFF
--- a/osdp/cdk.context.json
+++ b/osdp/cdk.context.json
@@ -56,5 +56,9 @@
         ]
       }
     ]
+  },
+  "hosted-zone:account=625046682746:domainName=rdc-staging.library.northwestern.edu:region=us-east-1": {
+    "Id": "/hostedzone/Z1W4E6BTU5QMUV",
+    "Name": "rdc-staging.library.northwestern.edu."
   }
 }

--- a/osdp/constructs/api_construct.py
+++ b/osdp/constructs/api_construct.py
@@ -141,4 +141,3 @@ class ApiConstruct(Construct):
 
         # Add API Gateway URL to outputs
         CfnOutput(self, "ApiUrl", value=self.api.url)
-        CfnOutput(self, "AllowedOrigins", value=",".join(allowed_origins))


### PR DESCRIPTION
### Summary

 - Configure `https://osdp.rdc-staging.library.northwestern.edu` to point to the deployed staging Amplify app.
 - It's a little too early to start considering how we want to approach all the many different ways domains could be configured by end users but it will drive us crazy to keep having Amplify urls during development. So this is meant to be temporary.

### Steps to test

In the dev environment, this should do nothing. So probably we'll have to merge and let it rip.