### PR TITLE
Update dockerfile

### DIFF
--- a/iiif/Dockerfile
+++ b/iiif/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 
 COPY pyproject.toml .
 RUN pip install uv
-RUN uv sync --group iiif
+RUN uv sync --only-group=iiif
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY manifest_fetcher.py .
 


### PR DESCRIPTION
## Description

Updates the `Dockerfile` for the `iiif/` ECR repo.

## Summary of changes

- prepends the `.venv` to the `PATH`
- only installs necessary deps

## Notes

In the previous iteration, though the deps were being installed, the virtual environment was not being activated.

Getting the right environment can be done by:

1. Activating it like `source .venv/bin/activate` or `. .venv/bin/activate`; the latter being used in the pipeline stack
2. [Prepending the virtual env binaries](https://docs.astral.sh/uv/guides/integration/docker/#using-the-environment) to the path `ENV PATH="/app/.venv/bin:$PATH"`
3. Using `uv` to run the command — `uv run manifest_fetcher.py`

I chose option 2 b/c it seemed like the fewest things could go wrong.

Additionally, because the `iiif` dir is so distinct from the rest of the repo, we can keep `boto3` in the `iiif` dependency group and use `uv sync --only-group=iiif` to install only `boto3` and `loam`. The previous command installed the main deps _and_ the iiif deps.

## Test

To test it locally run the following commands:

```bash
cp pyproject.toml iiif/
cd iiif
docker build --no-cache -t my-image .
docker run --rm -it my-image bash
```

And then inside the container run

```bash
which python
python -c 'import boto3; print(boto3.__version__)'
python -c 'import loam_iiif; print(loam_iiif)'
```