### PR TITLE
Update ephemeral storage

### DIFF
--- a/osdp/constructs/ui_construct.py
+++ b/osdp/constructs/ui_construct.py
@@ -95,7 +95,7 @@ class UIConstruct(Construct):
             },
             timeout=Duration.minutes(10),
             memory_size=1024,
-            ephemeral_storage_size=Size.gibibytes(1),
+            ephemeral_storage_size=Size.gibibytes(10),
             initial_policy=[
                 iam.PolicyStatement(
                     actions=["amplify:CreateDeployment", "amplify:StartDeployment"],


### PR DESCRIPTION
## Description

Updates the ephemeral storage to 2 gigs.

## Notes

During an invocation, I ran `execSync("du -sh /tmp/*", { encoding: "utf8", stdio: "inherit" });`, and while the total size of `/tmp` ended up being `865MB`, it failed during the next build which is hard to account for. 